### PR TITLE
Replaced shorthand array from seed stub

### DIFF
--- a/src/stubs/seed.php
+++ b/src/stubs/seed.php
@@ -4,9 +4,9 @@ class {{TableName}}TableSeeder extends Seeder {
 
 	public function run()
 	{
-		${{tableName}} = [
+		${{tableName}} = array(
 
-		];
+		);
 
 		DB::table('{{tableName}}')->insert(${{tableName}});
 	}


### PR DESCRIPTION
The package has a requirement of PHP >= 5.3.0 (and laravel has req of >= 5.3.7), however shorthand arrays only came about in PHP 5.4
http://php.net/manual/en/language.types.array.php
