### PR TITLE
Relationship support for Models

### DIFF
--- a/src/commands/GenerateResourceCommand.php
+++ b/src/commands/GenerateResourceCommand.php
@@ -45,7 +45,12 @@ class GenerateResourceCommand extends Generate {
 		$pluralName = Pluralizer::plural($name);
 
 		// Create the model
-		$this->call('generate:model', array('fileName' => $name));
+		$this->call('generate:model',
+			array(
+				'fileName' => $name,
+				'--relationships' => $this->option('relationships')
+			)
+		);
 
 
 		// Create the controller
@@ -125,7 +130,8 @@ class GenerateResourceCommand extends Generate {
 	protected function getOptions()
 	{
 		return array(
-			array('fields', null, InputOption::VALUE_OPTIONAL, 'Schema fields', null)
+			array('fields', null, InputOption::VALUE_OPTIONAL, 'Schema fields', null),
+		    array('relationships', null, InputOption::VALUE_OPTIONAL, 'Relationship options', null)
 		);
 	}
 


### PR DESCRIPTION
Usage : 

```
php artisan generate:model Baby --relationships="has_many:foo, has_one:buzz"
```

This will create 

```
<?php

class Baby extends Eloquent {

    public function foo() 
    {
        return $this->has_many('Foo');
    }
    public function buzz()
    {
        return $this->has_one('Buzz');
    }

}
```
