### PR TITLE
Fix to setDownMethod in the switch to have default in correct place

### DIFF
--- a/src/commands/GenerateMigrationCommand.php
+++ b/src/commands/GenerateMigrationCommand.php
@@ -193,10 +193,11 @@ class GenerateMigrationCommand extends Generate {
 
       case 'create':
       case 'make':
+      default:
         // then we need to drop the table in reverse
         $downMethod = \File::get(__DIR__ . '/../stubs/migrationDownDrop.php');
         $fields = $this->option('fields') ? $this->setFields('dropColumn') : '';
-      default:
+        break;
     }
 
     $downMethod = $this->replaceTableNameInTemplate($downMethod);


### PR DESCRIPTION
When running the generate:migration I ran into an error because default was not set in the correct place to create the $downMethod and $fields variable.
