### PR TITLE
Comment out the insert command in seeder stud

### DIFF
--- a/src/stubs/seed.php
+++ b/src/stubs/seed.php
@@ -8,7 +8,8 @@ class {{TableName}}TableSeeder extends Seeder {
 
 		);
 
-		DB::table('{{tableName}}')->insert(${{tableName}});
+		// Uncomment the below to run the seeder
+		// DB::table('{{tableName}}')->insert(${{tableName}});
 	}
 
 }


### PR DESCRIPTION
For the cases when you use `generate:resource` to get all the awesomeness of the auto generation of the migration file, controller, views, routes update etc, but you don't want to create any seeding, you currently have to go and manually change the seeder for the new resource.

If you leave the seeder file alone, there is a side effect that a blank row will be created in the table when you call `db:seed`.

This change comments out the insert command in the seeder that is created, so you can do a `migrate:refresh --seed` (or any other seeding call for that matter).

Since the user will be editing the file anyway if they are going to seed the table, they can uncomment it then, so ONLY those people need to edit the file, people who don't want to seed this particular resource can just leave the file alone and not have any side effects.
