### PR TITLE
Update symfony/finder requirement to be 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": "4.0.x",
-        "symfony/console": "2.2.*"
+        "symfony/console": "2.3.*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
When running a composer update, I'm getting the following:

it seems as though symfony/finder 2.2.x is requiring symfony/symfony 2.2, while laravel requires symfony/symfony 2.3 

This change simply updates the requirement of symfony/finder to 2.3 so as not to conflict

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove laravel/framework 4.0.x-dev
    - Installation request for way/generators dev-master -> satisfiable by way/generators dev-master.
    - don't install laravel/framework 4.0.x-dev|install laravel/framework dev-master
    - Installation request for laravel/framework 4.0.x-dev -> satisfiable by laravel/framework 4.0.x-dev.
    - way/generators dev-master requires symfony/console 2.2.* -> satisfiable by symfony/console 2.2.x-dev, symfony/symfony 2.2.x-dev, symfony/symfony v2.2.0, symfony/symfony v2.2.0-BETA1, symfony/symfony v2.2.0-BETA2, symfony/symfony v2.2.0-RC1, symfony/symfony v2.2.0-RC2, symfony/symfony v2.2.0-RC3, symfony/symfony v2.2.1, symfony/console 2.2.x-dev, symfony/console v2.2.0, symfony/console v2.2.0-BETA1, symfony/console v2.2.0-BETA2, symfony/console v2.2.0-RC1, symfony/console v2.2.0-RC2, symfony/console v2.2.0-RC3, symfony/console v2.2.1.
    - Can only install one of: symfony/symfony 2.3.x-dev, symfony/symfony 2.2.x-dev.
    - Can only install one of: symfony/symfony v2.2.0, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.0-BETA1, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.0-BETA2, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.0-RC1, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.0-RC2, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.0-RC3, symfony/symfony 2.3.x-dev.
    - Can only install one of: symfony/symfony v2.2.1, symfony/symfony 2.3.x-dev.
    - don't install symfony/symfony 2.3.x-dev|remove symfony/console 2.2.x-dev
    - don't install symfony/console 2.2.x-dev|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0-BETA1|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0-BETA2|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0-RC1|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0-RC2|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.0-RC3|don't install symfony/symfony 2.3.x-dev
    - don't install symfony/console v2.2.1|don't install symfony/symfony 2.3.x-dev
    - laravel/framework dev-master requires symfony/browser-kit 2.3.* -> satisfiable by symfony/symfony 2.3.x-dev, symfony/browser-kit 2.3.x-dev.
    - Conclusion: don't install symfony/browser-kit 2.3.x-dev
```
