### PR TITLE
Fixes migrations for multi-named tables

### DIFF
--- a/src/commands/GenerateMigrationCommand.php
+++ b/src/commands/GenerateMigrationCommand.php
@@ -94,7 +94,11 @@ class GenerateMigrationCommand extends Generate {
     $tableName = end($pieces);
     if ( $tableName === 'table' )
     {
-      $tableName = prev($pieces);
+      $tableName = '';
+      while($part = prev($pieces) and $part !== $action) 
+      {
+        $tableName = $part . (!empty($tableName) ? '_' : '') . $tableName;
+      }
     }
 
     // For example: ['add', 'posts']


### PR DESCRIPTION
Currently, when we try to create a migration for a table with more than one name, like 'office_room', generator creates up() and down() methods for 'room'. This is a fix for it.

artisan generate:migration create_office_room_table
