### PR TITLE
Fix for custom table names

### DIFF
--- a/src/Way/Generators/Generators/FormDumperGenerator.php
+++ b/src/Way/Generators/Generators/FormDumperGenerator.php
@@ -223,7 +223,7 @@ class FormDumperGenerator {
      */
     protected function getTableName($model)
     {
-        return (new $model)->getTable() ? (new $model)->getTable() : Pluralizer::plural($model);
+        return (new $model)->getTable() ?: Pluralizer::plural($model);
     }
 
 }


### PR DESCRIPTION
Example:

```
class User extends Eloquent {

    protected $table = 'my_users';

}
```

Fun fact: I got haunted by two bugs in the same call to generate:form, this one, because in one app my tables need to be in portugese and another one, because I'm using Postgres, and getColumns() was returning no columns at all, but it was a bug in Doctrine, wich is now fixed here: https://github.com/doctrine/dbal/pull/307.
