### PR TITLE
Remove short array syntax for compatability with PHP < 5.4

### DIFF
--- a/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
+++ b/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
@@ -15,7 +15,7 @@ class {{className}} extends TestCase {
     {
         parent::setUp();
 
-        $this->attributes = Factory::{{model}}(['id' => 1]);
+        $this->attributes = Factory::{{model}}(array('id' => 1));
         $this->app->instance('{{Model}}', $this->mock);
     }
 
@@ -88,7 +88,7 @@ class {{className}} extends TestCase {
     {
         $this->mock->shouldReceive('find')
                    ->with(1)
-                   ->andReturn(m::mock(['update' => true]));
+                   ->andReturn(m::mock(array('update' => true)));
 
         $this->validate(true);
         $this->call('PATCH', '{{pluralModel}}/1');
@@ -98,7 +98,7 @@ class {{className}} extends TestCase {
 
     public function testUpdateFails()
     {
-        $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(['update' => true]));
+        $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(array('update' => true)));
         $this->validate(false);
         $this->call('PATCH', '{{pluralModel}}/1');
 
@@ -109,7 +109,7 @@ class {{className}} extends TestCase {
 
     public function testDestroy()
     {
-        $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(['delete' => true]));
+        $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(array('delete' => true)));
 
         $this->call('DELETE', '{{pluralModel}}/1');
     }
@@ -118,6 +118,6 @@ class {{className}} extends TestCase {
     {
         Validator::shouldReceive('make')
                 ->once()
-                ->andReturn(m::mock(['passes' => $bool]));
+                ->andReturn(m::mock(array('passes' => $bool)));
     }
 }

--- a/src/Way/Generators/Generators/templates/scaffold/views/single/create.txt
+++ b/src/Way/Generators/Generators/templates/scaffold/views/single/create.txt
@@ -2,7 +2,7 @@
 
 <h1>Create {{className}}</h1>
 
-{{ Form::open(['route' => '{{pluralModel}}.store']) }}
+{{ Form::open(array('route' => '{{pluralModel}}.store')) }}
     <ul>
 {{formElements}}
         <li>

--- a/tests/commands/ControllerGeneratorCommandTest.php
+++ b/tests/commands/ControllerGeneratorCommandTest.php
@@ -21,7 +21,7 @@ class ControllerGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ControllerGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'FooController', '--template' => 'foo']);
+        $tester->execute(array('name' => 'FooController', '--template' => 'foo'));
 
         $this->assertEquals("Created app/controllers/FooController.php\n", $tester->getDisplay());
     }
@@ -34,7 +34,7 @@ class ControllerGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ControllerGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'FooController', '--path' => 'app', '--template' => 'foo']);
+        $tester->execute(array('name' => 'FooController', '--path' => 'app', '--template' => 'foo'));
 
         $this->assertEquals("Created app/FooController.php\n", $tester->getDisplay());
     }
@@ -50,7 +50,7 @@ class ControllerGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ControllerGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'FooController', '--template' => 'foo']);
+        $tester->execute(array('name' => 'FooController', '--template' => 'foo'));
     }
 
 }

--- a/tests/commands/ModelGeneratorCommandTest.php
+++ b/tests/commands/ModelGeneratorCommandTest.php
@@ -21,7 +21,7 @@ class ModelGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ModelGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'foo']);
+        $tester->execute(array('name' => 'foo'));
 
         $this->assertEquals("Created app/models/Foo.php\n", $tester->getDisplay());
     }
@@ -38,7 +38,7 @@ class ModelGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ModelGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'Foo']);
+        $tester->execute(array('name' => 'Foo'));
 
         $this->assertEquals("Could not create app/models/Foo.php\n", $tester->getDisplay());
     }
@@ -54,6 +54,6 @@ class ModelGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         $command = new ModelGeneratorCommand($gen);
 
         $tester = new CommandTester($command);
-        $tester->execute(['name' => 'foo', '--path' => 'app/foo/models']);
+        $tester->execute(array('name' => 'foo', '--path' => 'app/foo/models'));
     }
 }

--- a/tests/commands/ScafoldGeneratorCommandTest.php
+++ b/tests/commands/ScafoldGeneratorCommandTest.php
@@ -16,7 +16,7 @@ class ScaffoldGeneratorCommandTest extends PHPUnit_Framework_TestCase {
         // $command = new ScaffoldGeneratorCommand;
 
         // $tester = new CommandTester($command);
-        // $tester->execute(['name' => 'dog']);
+        // $tester->execute(array('name' => 'dog'));
     }
 
 }

--- a/tests/generators/FormDumperGeneratorTest.php
+++ b/tests/generators/FormDumperGeneratorTest.php
@@ -63,7 +63,7 @@ class FormDumperGeneratorTest extends PHPUnit_Framework_TestCase {
         $form->shouldReceive('getTableInfo')
              ->once()
              ->with('dog')
-             ->andReturn(['name' => 'string']);
+             ->andReturn(array('name' => 'string'));
 
         return $form;
     }

--- a/tests/generators/ModelGeneratorTest.php
+++ b/tests/generators/ModelGeneratorTest.php
@@ -53,7 +53,7 @@ class ModelGeneratorTest extends PHPUnit_Framework_TestCase {
 
         $cache->shouldReceive('getFields')
               ->once()
-              ->andReturn(['title' => 'string', 'age' => 'integer']);
+              ->andReturn(array('title' => 'string', 'age' => 'integer'));
 
         $file->shouldReceive('put')
              ->once()


### PR DESCRIPTION
As I commented in #84, if you are running PHP CLI < 5.4, you will receive an "unexpected '['" error. Reverted back to array('key' => 'value') from the short array syntax ['key' => 'value']. Should now be 5.3 compatible. Note: I also initiated a pull request for JeffreyWay/Laravel-Test-Helpers repo to fix the same issue. Thanks!
