### PR TITLE
Allow multiple indexes/options when adding columns in a migration

### DIFF
--- a/src/Way/Generators/Generators/MigrationGenerator.php
+++ b/src/Way/Generators/Generators/MigrationGenerator.php
@@ -163,6 +163,8 @@ class MigrationGenerator extends Generator {
 
         $template = array_map(array($this, $method), $fields);
 
+        var_dump($template); exit;
+
         return implode("\n\t\t\t", $template);
     }
 
@@ -192,11 +194,20 @@ class MigrationGenerator extends Generator {
             $bit->name = $columnInfo[0];
             $bit->type = $columnInfo[1];
 
-            // If there is a third key, then
-            // the user is setting an index/option.
-            if ( isset($columnInfo[2]) )
+            // If there are more keys, then
+            // the user is setting indexes/options.
+            $i = 2;
+
+            while(isset($columnInfo[$i]))
             {
-                $bit->index = $columnInfo[2];
+                if( !isset($bit->indexes))
+                {
+                    $bit->indexes = array();
+                }
+
+                $bit->indexes[] = $columnInfo[$i];
+
+                $i++;
             }
         }
 
@@ -228,11 +239,14 @@ class MigrationGenerator extends Generator {
             : "('{$field->name}')";
 
         // Take care of any potential indexes or options
-        if ( isset($field->index) )
+        if ( isset($field->indexes) )
         {
-            $html .= str_contains($field->index, '(')
-                ? "->{$field->index}"
-                : "->{$field->index}()";
+            foreach($field->indexes as $index)
+            {
+                $html .= str_contains($index, '(')
+                    ? "->{$index}"
+                    : "->{$index}()";
+            }
         }
 
         return $html.';';


### PR DESCRIPTION
Allows things like --fields="numberOfCakes:integer:unsigned:nullable", where previously only one index or option was allowed.
