### PR TITLE
Allow multiple indexes/options when add columns in a migration

### DIFF
--- a/src/Way/Generators/Generators/MigrationGenerator.php
+++ b/src/Way/Generators/Generators/MigrationGenerator.php
@@ -163,8 +163,6 @@ class MigrationGenerator extends Generator {
 
         $template = array_map(array($this, $method), $fields);
 
-        var_dump($template); exit;
-
         return implode("\n\t\t\t", $template);
     }
 


### PR DESCRIPTION
Allows things like "numberOfCakes:integer:nullable:unsigned" whereas previously you could only use one option or index.
