### PR TITLE
Auto-escape fields

### DIFF
--- a/src/Way/Generators/Generators/ViewGenerator.php
+++ b/src/Way/Generators/Generators/ViewGenerator.php
@@ -82,7 +82,7 @@ class ViewGenerator extends Generator {
 
         // And then the rows, themselves
         $fields = array_map(function($field) use ($model) {
-            return "<td>{{ \$$model->$field }}</td>";
+            return "<td>{{{ \$$model->$field }}}</td>";
         }, array_keys($fields));
 
         // Now, we'll add the edit and delete buttons.


### PR DESCRIPTION
The description is here
https://github.com/JeffreyWay/Laravel-4-Generators/issues/109

Basically, the default scaffold generator uses `{{ }}` notation
which does not escape HTML properly and is subject to XSS.
