### PR TITLE
Table/Controller complex names fix.

### DIFF
--- a/src/Way/Generators/Commands/ControllerGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ControllerGeneratorCommand.php
@@ -4,6 +4,7 @@ use Way\Generators\Generators\ControllerGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
 
 class ControllerGeneratorCommand extends BaseGeneratorCommand {
 
@@ -47,7 +48,7 @@ class ControllerGeneratorCommand extends BaseGeneratorCommand {
      */
     protected function getPath()
     {
-       return $this->option('path') . '/' . ucwords($this->argument('name')) . '.php';
+       return $this->option('path') . '/' . Str::studly($this->argument('name')) . '.php';
     }
 
     /**

--- a/src/Way/Generators/Commands/MigrationGeneratorCommand.php
+++ b/src/Way/Generators/Commands/MigrationGeneratorCommand.php
@@ -67,7 +67,7 @@ class MigrationGeneratorCommand extends BaseGeneratorCommand
      */
     protected function getPath()
     {
-       return $this->option('path') . '/' . ucwords($this->argument('name')) . '.php';
+       return $this->option('path') . '/' . $this->argument('name') . '.php';
     }
 
     /**

--- a/src/Way/Generators/Commands/ModelGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ModelGeneratorCommand.php
@@ -4,6 +4,7 @@ use Way\Generators\Generators\ModelGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
 
 class ModelGeneratorCommand extends BaseGeneratorCommand {
 
@@ -47,7 +48,7 @@ class ModelGeneratorCommand extends BaseGeneratorCommand {
      */
     protected function getPath()
     {
-       return $this->option('path') . '/' . ucwords($this->argument('name')) . '.php';
+       return $this->option('path') . '/' . Str::studly($this->argument('name')) . '.php';
     }
 
 	/**

--- a/src/Way/Generators/Commands/ResourceGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ResourceGeneratorCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
 use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
 
 class MissingFieldsException extends \Exception {}
 
@@ -149,7 +150,7 @@ class ResourceGeneratorCommand extends Command {
      */
    protected function generateController()
     {
-        $name = Pluralizer::plural($this->model);
+        $name = Str::studly(Pluralizer::plural($this->model));
 
         $this->call(
             'generate:controller',

--- a/src/Way/Generators/Commands/SeedGeneratorCommand.php
+++ b/src/Way/Generators/Commands/SeedGeneratorCommand.php
@@ -4,6 +4,7 @@ use Way\Generators\Generators\SeedGenerator;
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
 
 class SeedGeneratorCommand extends BaseGeneratorCommand {
 
@@ -66,7 +67,7 @@ class SeedGeneratorCommand extends BaseGeneratorCommand {
      */
     protected function getPath()
     {
-        return $this->option('path') . '/' . ucwords($this->argument('name')) . 'TableSeeder.php';
+        return $this->option('path') . '/' . Str::studly($this->argument('name')) . 'TableSeeder.php';
     }
 
     /**

--- a/src/Way/Generators/Generators/ControllerGenerator.php
+++ b/src/Way/Generators/Generators/ControllerGenerator.php
@@ -4,6 +4,7 @@ namespace Way\Generators\Generators;
 
 use Illuminate\Filesystem\Filesystem as File;
 use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
 
 class ControllerGenerator extends Generator {
 
@@ -23,7 +24,7 @@ class ControllerGenerator extends Generator {
             $this->template = $this->getScaffoldedController($template, $name);
         }
 
-        return str_replace('{{name}}', $name, $this->template);
+        return str_replace('{{name}}', Str::studly($name), $this->template);
     }
 
     /**
@@ -35,9 +36,9 @@ class ControllerGenerator extends Generator {
      */
     protected function getScaffoldedController($template, $name)
     {
-        $collection = strtolower(str_replace('Controller', '', $name)); // dogs
-        $modelInstance = Pluralizer::singular($collection); // dog
-        $modelClass = ucwords($modelInstance); // Dog
+        $collection = Str::snake(str_replace('Controller', '', $name)); // dog_kinds
+        $modelInstance = Pluralizer::singular($collection); // dog_kind
+        $modelClass = Str::studly($modelInstance); // DogKind
 
         foreach(array('modelInstance', 'modelClass', 'collection') as $var)
         {

--- a/src/Way/Generators/Generators/MigrationGenerator.php
+++ b/src/Way/Generators/Generators/MigrationGenerator.php
@@ -2,7 +2,30 @@
 
 namespace Way\Generators\Generators;
 
+use Way\Generators\Cache;
+use Illuminate\Filesystem\Filesystem as File;
+use Illuminate\Support\Str;
+
 class MigrationGenerator extends Generator {
+
+    /**
+     * Date of migration creation
+     *
+     * @var string
+     */
+    public $date;
+
+    /**
+     * Constructor
+     *
+     * @param $file
+     */
+    public function __construct(File $file, Cache $cache)
+    {
+        parent::__construct($file, $cache);
+
+        $this->date = date('Y_m_d_His');
+    }
 
     /**
      * Fetch the compiled template for a migration
@@ -17,7 +40,7 @@ class MigrationGenerator extends Generator {
         $stub = $this->file->get(__DIR__.'/templates/migration/migration.txt');
 
         // Next, set the migration class name
-        $stub = str_replace('{{name}}', \Str::studly($name), $stub);
+        $stub = str_replace('{{name}}', Str::studly($name), $stub);
 
         // Now, we're going to handle the tricky
         // work of creating the Schema
@@ -61,17 +84,19 @@ class MigrationGenerator extends Generator {
         // add_user_id_to_posts_table
         $pieces = explode('_', $name);
 
-        $action = $pieces[0];
+        $action = array_shift($pieces);
 
         // If the migration name is create_users,
         // then we'll set the tableName to the last
         // item. But, if it's create_users_table,
         // then we have to compensate, accordingly.
-        $tableName = end($pieces);
-        if ( $tableName === 'table' )
+
+        if ( end($pieces) === 'table' )
         {
-            $tableName = prev($pieces);
+            array_pop($pieces);
         }
+
+        $tableName = implode('_', $pieces);
 
         // For example: ['add', 'posts']
         return array($action, $tableName);
@@ -253,7 +278,7 @@ class MigrationGenerator extends Generator {
     {
         $migrationFile = strtolower(basename($path));
 
-        return dirname($path).'/'.date('Y_m_d_His').'_'.$migrationFile;
+        return dirname($path).'/'.$this->date.'_'.$migrationFile;
     }
 
 }

--- a/src/Way/Generators/Generators/ModelGenerator.php
+++ b/src/Way/Generators/Generators/ModelGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Way\Generators\Generators;
 
+use Illuminate\Support\Str;
+
 class ModelGenerator extends Generator {
 
     /**
@@ -20,7 +22,7 @@ class ModelGenerator extends Generator {
             $this->template = $this->getScaffoldedModel($name);
         }
 
-        return str_replace('{{name}}', $name, $this->template);
+        return str_replace('{{name}}', Str::studly($name), $this->template);
     }
 
     /**

--- a/src/Way/Generators/Generators/ResourceGenerator.php
+++ b/src/Way/Generators/Generators/ResourceGenerator.php
@@ -4,6 +4,7 @@ namespace Way\Generators\Generators;
 
 use Illuminate\Filesystem\Filesystem as File;
 use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
 
 class ResourceGenerator {
 
@@ -36,7 +37,7 @@ class ResourceGenerator {
 
         $this->file->append(
             app_path() . '/routes.php',
-            "\n\nRoute::resource('" . $name . "', '" . ucwords($name) . "Controller');"
+            "\n\nRoute::resource('" . $name . "', '" . Str::studly($name) . "Controller');"
         );
     }
 

--- a/src/Way/Generators/Generators/ScaffoldGenerator.php
+++ b/src/Way/Generators/Generators/ScaffoldGenerator.php
@@ -4,6 +4,7 @@ namespace Way\Generators\Generators;
 
 use Illuminate\Filesystem\Filesystem as File;
 use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
 
 class ScaffoldGenerator {
 
@@ -36,7 +37,7 @@ class ScaffoldGenerator {
 
         $this->file->append(
             app_path() . '/routes.php',
-            "\n\nRoute::resource('" . $name . "', '" . ucwords($name) . "Controller');"
+            "\n\nRoute::resource('" . $name . "', '" . Str::studly($name) . "Controller');"
         );
     }
 

--- a/src/Way/Generators/Generators/SeedGenerator.php
+++ b/src/Way/Generators/Generators/SeedGenerator.php
@@ -2,6 +2,8 @@
 
 namespace Way\Generators\Generators;
 
+use Illuminate\Support\Str;
+
 class SeedGenerator extends Generator {
 
     /**
@@ -14,7 +16,7 @@ class SeedGenerator extends Generator {
     protected function getTemplate($template, $className)
     {
         $this->template = $this->file->get($template);
-        $pluralModel = strtolower(str_replace('TableSeeder', '', $className));
+        $pluralModel = Str::snake(str_replace('TableSeeder', '', $className));
 
         $this->template = str_replace('{{className}}', $className, $this->template);
 

--- a/src/Way/Generators/Generators/TestGenerator.php
+++ b/src/Way/Generators/Generators/TestGenerator.php
@@ -2,6 +2,9 @@
 
 namespace Way\Generators\Generators;
 
+use Illuminate\Support\Pluralizer;
+use Illuminate\Support\Str;
+
 class TestGenerator extends Generator {
 
     /**
@@ -13,13 +16,13 @@ class TestGenerator extends Generator {
      */
     protected function getTemplate($template, $className)
     {
-        $pluralModel = strtolower(str_replace('Test', '', $className)); //  dogs
-        $model = str_singular($pluralModel); // dog
-        $Model = ucwords($model); // Dog
+        $collection = Str::snake(str_replace('Test', '', $className)); //  dog_kinds
+        $modelInstance = Pluralizer::singular($collection); // dog_kind
+        $modelClass = Str::studly($modelInstance); // DogKind
 
         $template = $this->file->get($template);
 
-        foreach(array('pluralModel', 'model', 'Model', 'className') as $var)
+        foreach(array('collection', 'modelInstance', 'modelClass', 'className') as $var)
         {
             $template = str_replace('{{'.$var.'}}', $$var, $template);
         }

--- a/src/Way/Generators/Generators/ViewGenerator.php
+++ b/src/Way/Generators/Generators/ViewGenerator.php
@@ -77,7 +77,7 @@ class ViewGenerator extends Generator {
 
         // First, we build the table headings
         $headings = array_map(function($field) {
-            return '<th>' . ucwords($field) . '</th>';
+            return '<th>' . ucwords(str_replace(array('-', '_'), ' ', $field)) . '</th>';
         }, array_keys($fields));
 
         // And then the rows, themselves
@@ -110,7 +110,7 @@ EOT;
 
         foreach($this->cache->getFields() as $name => $type)
         {
-            $formalName = ucwords($name);
+            $formalName = ucwords(str_replace(array('-', '_'), ' ', $name));
 
             // TODO: add remaining types
             switch($type)

--- a/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
+++ b/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
@@ -7,7 +7,7 @@ class {{className}} extends TestCase {
 
     public function __construct()
     {
-        $this->mock = m::mock('Eloquent', '{{Model}}');
+        $this->mock = m::mock('Eloquent', '{{modelClass}}');
         $this->collection = m::mock('Illuminate\Database\Eloquent\Collection')->shouldDeferMissing();
     }
 
@@ -15,8 +15,8 @@ class {{className}} extends TestCase {
     {
         parent::setUp();
 
-        $this->attributes = Factory::{{model}}(['id' => 1]);
-        $this->app->instance('{{Model}}', $this->mock);
+        $this->attributes = Factory::{{modelInstance}}(['id' => 1]);
+        $this->app->instance('{{modelClass}}', $this->mock);
     }
 
     public function tearDown()
@@ -27,14 +27,14 @@ class {{className}} extends TestCase {
     public function testIndex()
     {
         $this->mock->shouldReceive('all')->once()->andReturn($this->collection);
-        $this->call('GET', '{{pluralModel}}');
+        $this->call('GET', '{{collection}}');
 
-        $this->assertViewHas('{{pluralModel}}');
+        $this->assertViewHas('{{collection}}');
     }
 
     public function testCreate()
     {
-        $this->call('GET', '{{pluralModel}}/create');
+        $this->call('GET', '{{collection}}/create');
 
         $this->assertResponseOk();
     }
@@ -43,18 +43,18 @@ class {{className}} extends TestCase {
     {
         $this->mock->shouldReceive('create')->once();
         $this->validate(true);
-        $this->call('POST', '{{pluralModel}}');
+        $this->call('POST', '{{collection}}');
 
-        $this->assertRedirectedToRoute('{{pluralModel}}.index');
+        $this->assertRedirectedToRoute('{{collection}}.index');
     }
 
     public function testStoreFails()
     {
         $this->mock->shouldReceive('create')->once();
         $this->validate(false);
-        $this->call('POST', '{{pluralModel}}');
+        $this->call('POST', '{{collection}}');
 
-        $this->assertRedirectedToRoute('{{pluralModel}}.create');
+        $this->assertRedirectedToRoute('{{collection}}.create');
         $this->assertSessionHasErrors();
         $this->assertSessionHas('message');
     }
@@ -66,9 +66,9 @@ class {{className}} extends TestCase {
                    ->once()
                    ->andReturn($this->attributes);
 
-        $this->call('GET', '{{pluralModel}}/1');
+        $this->call('GET', '{{collection}}/1');
 
-        $this->assertViewHas('{{model}}');
+        $this->assertViewHas('{{modelInstance}}');
     }
 
     public function testEdit()
@@ -79,9 +79,9 @@ class {{className}} extends TestCase {
                    ->once()
                    ->andReturn($this->collection);
 
-        $this->call('GET', '{{pluralModel}}/1/edit');
+        $this->call('GET', '{{collection}}/1/edit');
 
-        $this->assertViewHas('{{model}}');
+        $this->assertViewHas('{{modelInstance}}');
     }
 
     public function testUpdate()
@@ -91,18 +91,18 @@ class {{className}} extends TestCase {
                    ->andReturn(m::mock(['update' => true]));
 
         $this->validate(true);
-        $this->call('PATCH', '{{pluralModel}}/1');
+        $this->call('PATCH', '{{collection}}/1');
 
-        $this->assertRedirectedTo('{{pluralModel}}/1');
+        $this->assertRedirectedTo('{{collection}}/1');
     }
 
     public function testUpdateFails()
     {
         $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(['update' => true]));
         $this->validate(false);
-        $this->call('PATCH', '{{pluralModel}}/1');
+        $this->call('PATCH', '{{collection}}/1');
 
-        $this->assertRedirectedTo('{{pluralModel}}/1/edit');
+        $this->assertRedirectedTo('{{collection}}/1/edit');
         $this->assertSessionHasErrors();
         $this->assertSessionHas('message');
     }
@@ -111,7 +111,7 @@ class {{className}} extends TestCase {
     {
         $this->mock->shouldReceive('find')->with(1)->andReturn(m::mock(['delete' => true]));
 
-        $this->call('DELETE', '{{pluralModel}}/1');
+        $this->call('DELETE', '{{collection}}/1');
     }
 
     protected function validate($bool)


### PR DESCRIPTION
Hi Jeffrey,

So, I faced a problem when tried to use generators for complex table/controller names. Here is an example:

`./artisan generate:scaffold contact_nicknames --fields="contact_id:integer, contact_nickname:string"`

This command will generate the following files:
- app/models/Contact_nickname.php
- app/controllers/Contact_nicknamesController.php
- app/views/contact_nicknames/index.blade.php
- (...) views
- app/database/seeds/Contact_nicknamesTableSeeder.php
- app/tests/controllers/ContactNicknamesTest.php

Also, it will generate classes like these:
- class Contact_nicknamesController extends BaseController
- class Contact_nicknamesTableSeeder extends Seeder
- class Contact_nickname extends Eloquent

In addition, in migration it uses only last part of the table name.

Thus, I've done this fix for complex naming lovers like me.

Also fixed: stdout names for generated migrations: dates added, when generating Scaffold.
Variables naming fix in controller tests generator to match ControllerGenerator code style.

Hope code meets the standards, but if you will find anything weird, please let me know.
