### PR TITLE
Add date to migration file name

### DIFF
--- a/src/Way/Generators/Commands/MigrationGeneratorCommand.php
+++ b/src/Way/Generators/Commands/MigrationGeneratorCommand.php
@@ -61,6 +61,17 @@ class MigrationGeneratorCommand extends BaseGeneratorCommand
     }
 
     /**
+     * Same as base method, but adds the date to the file name
+     * @param  boolean $successful
+     * @param  string $path
+     * @return string
+     */
+    protected function printResult($successful, $path)
+    {
+        return parent::printResult($successful, dirname($path).'/'.$this->generator->date.'_'.basename($path));
+    }
+
+    /**
      * Get the path to the file that should be generated
      *
      * @return string


### PR DESCRIPTION
Currently, the output after generating a migration contains an incorrect file name (the date part is omitted). This affects the Sublime Text 2 plugin, preventing it from opening the newly generated migration.
I've overridden the printResult() method in MigrationGeneratorCommand, adding the date to the output. If this is an improper way, please let me know.
