### PR TITLE
Generate files format compatibility issue on osx

### DIFF
--- a/src/Way/Generators/Generators/ViewGenerator.php
+++ b/src/Way/Generators/Generators/ViewGenerator.php
@@ -24,7 +24,7 @@ class ViewGenerator extends Generator {
 
         // Otherwise, just set the file
         // contents to the file name
-        return $name;
+        return $name . PHP_EOL;
     }
 
     /**


### PR DESCRIPTION
Run this command `artisan generate:view test` generate view file

But this view file newline format is `Carriage Return(\r)` not `Line feed(\n)`

So this problem will affect the view compilation

![view file](https://f.cloud.github.com/assets/1356974/743703/930a3ae0-e3ed-11e2-83c9-d774747847b6.png)

![compile error](https://f.cloud.github.com/assets/1356974/743684/3cb4d4b6-e3ed-11e2-9ab1-3117c337f94e.png)
