### PR TITLE
Fix generate view file format

### DIFF
--- a/src/Way/Generators/Generators/ViewGenerator.php
+++ b/src/Way/Generators/Generators/ViewGenerator.php
@@ -24,7 +24,7 @@ class ViewGenerator extends Generator {
 
         // Otherwise, just set the file
         // contents to the file name
-        return $name;
+        return $name . PHP_EOL;
     }
 
     /**


### PR DESCRIPTION
On mac osx, I use `generate:view` command  generate view file format is wrong.

This problem will beget `syntax error`

![view file](https://f.cloud.github.com/assets/1356974/743703/930a3ae0-e3ed-11e2-83c9-d774747847b6.png)

![syntax error](https://f.cloud.github.com/assets/1356974/743684/3cb4d4b6-e3ed-11e2-9ab1-3117c337f94e.png)
