### PR TITLE
Add 'deleted_at' to non-essential attributes array.

### DIFF
--- a/src/Way/Generators/Generators/FormDumperGenerator.php
+++ b/src/Way/Generators/Generators/FormDumperGenerator.php
@@ -91,7 +91,7 @@ class FormDumperGenerator {
     {
         $names = array_keys($table);
 
-        return array_diff($names, array('id', 'created_at', 'updated_at', 'password'));
+        return array_diff($names, array('id', 'created_at', 'updated_at', 'deleted_at','password'));
     }
 
     /**


### PR DESCRIPTION
When using soft delete a "deleted_at" timestamp is set on the record and the form generator dumps that too.
