### PR TITLE
Update MigrationGenerator to return correct path

### DIFF
--- a/src/Way/Generators/Commands/MigrationGeneratorCommand.php
+++ b/src/Way/Generators/Commands/MigrationGeneratorCommand.php
@@ -55,6 +55,10 @@ class MigrationGeneratorCommand extends BaseGeneratorCommand
                         ->parse($name, $fields)
                         ->make($path, null);
 
+        if ($created) {
+            $path = $this->generator->path;
+        }
+
         $this->call('dump-autoload');
 
         $this->printResult($created, $path);


### PR DESCRIPTION
Maybe for the other generators this would work, but migrations turn the path provided into the migration-like path, so if the generation succeeded, we get the path from the generator's public `path` field directly, which was updated during the generation process.
