### PR TITLE
More validation rules depending on the field type

### DIFF
--- a/src/Way/Generators/Generators/ModelGenerator.php
+++ b/src/Way/Generators/Generators/ModelGenerator.php
@@ -37,9 +37,28 @@ class ModelGenerator extends Generator {
             return str_replace('{{rules}}', '', $this->template);
         }
 
-        $rules = array_map(function($field) {
-            return "'$field' => 'required'";
-        }, array_keys($fields));
+        $rules = array();
+        array_walk($fields, function($type, $field) use (&$rules) {
+            $rule = 'required';
+            switch($type) {
+                case 'integer':
+                case 'bigInteger':
+                case 'smallInteger':
+                case 'boolean':
+                    $rule .= '|integer';
+                    break;
+                case 'float':
+                    $rule .= '|numeric';
+                    break;
+                case 'date':
+                case 'time':
+                case 'datetime':
+                case 'timestamp':
+                    $rule .= '|date';
+                    break;
+            }
+            $rules[] = "'$field' => '$rule'";
+        });
 
         return str_replace('{{rules}}', PHP_EOL."\t\t".implode(','.PHP_EOL."\t\t", $rules) . PHP_EOL."\t", $this->template);
     }

--- a/tests/generators/stubs/scaffold/model.txt
+++ b/tests/generators/stubs/scaffold/model.txt
@@ -5,6 +5,6 @@ class Foo extends Eloquent {
 
     public static $rules = array(
 		'title' => 'required',
-		'age' => 'required'
+		'age' => 'required|integer'
 	);
 }


### PR DESCRIPTION
Add validation rules automatically depending on field type, for now here are the validation rules added:

Field type `integer` `bigInteger` `smallInteger` `boolean`  => `integer`
Field type `float`  => `numeric`
Field type `date` `time` `datetime` `timestamp`  => `date`

All field types still have the `required` rule.
