### PR TITLE
adding support for generating test methods for classes that already exis...

### DIFF
--- a/src/Way/Generators/Generators/TestGenerator.php
+++ b/src/Way/Generators/Generators/TestGenerator.php
@@ -17,6 +17,12 @@ class TestGenerator extends Generator {
         $model = str_singular($pluralModel); // dog
         $Model = ucwords($model); // Dog
 
+        $methods = $this->generateTestMethods($className);
+
+        if($methods) {
+            return $this->generateTemplate($className, $methods);
+        }
+
         $template = $this->file->get($template);
 
         foreach(array('pluralModel', 'model', 'Model', 'className') as $var)
@@ -24,6 +30,45 @@ class TestGenerator extends Generator {
             $template = str_replace('{{'.$var.'}}', $$var, $template);
         }
 
+        return $template;
+    }
+
+    /**
+     * Generate test methods for a given class
+     *
+     * @param  string $className
+     * @return array|false List of methods or false if the class does not exist
+     */
+    protected function generateTestMethods($className) {
+        try {
+            $class = new \ReflectionClass(str_replace('Test', '', $className));
+            $methods = $class->getMethods();
+            $testMethods = array();
+        } catch (\Exception $e) {
+            return false;
+        }
+
+        foreach ($methods as $method) {
+            if($method->class == $class->name && $method->name != '__construct')
+                $testMethods[] = 'test' . ucwords($method->name);
+        }
+        return $testMethods;
+    }
+
+    /**
+     * Generate a template with methods for the given class
+     *
+     * @param  string $className
+     * @param  array List of method names
+     * @return string Compiled template
+     */
+    protected  function generateTemplate($className, $methods) {
+        $template = "<?php \n\nclass $className extends TestCase {\n\n";
+
+        foreach ($methods as $m) {
+            $template .= "\tpublic function $m()\n\t{\n\n\t}\n\n";
+        }
+        $template .= "}";
         return $template;
     }
 


### PR DESCRIPTION
It would be a great feature if the generator could create a test class with all the methods that exist in a particular class.
For example if I have a previously created controller called `UserController` and it has the methods `index`, `edit` and `update` I would simply write:

`php artisan generate:test UserControllerTest`

and the reflector would scan if a class called `UserController` exists and extract its methods. It would than generate a template like this

``` php
<?php 

class UserControllerTest extends TestCase {

    public function testIndex()
    {

    }

    public function testEdit()
    {

    }

    public function testUpdate()
    {

    }

}
```

This would be useful for controllers that are not created with generator and have a lot of methods.
