### PR TITLE
Prevents appending the same route to routes.php more than once

### DIFF
--- a/src/Way/Generators/Commands/ResourceGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ResourceGeneratorCommand.php
@@ -87,8 +87,14 @@ class ResourceGeneratorCommand extends Command {
             $this->generateTest();
         }
 
-        $this->generator->updateRoutesFile($this->model);
-        $this->info('Updated ' . app_path() . '/routes.php');
+        if ($this->generator->updateRoutesFile($this->model))
+        {
+            $this->info('Updated ' . app_path() . '/routes.php');
+        }
+        else
+        {
+            $this->comment('Did not need to update ' . app_path() . '/routes.php');
+        }
 
         // We're all finished, so we
         // can delete the cache.

--- a/src/Way/Generators/Generators/ResourceGenerator.php
+++ b/src/Way/Generators/Generators/ResourceGenerator.php
@@ -25,7 +25,7 @@ class ResourceGenerator {
     }
 
     /**
-     * Update app/routes.php
+     * Update app/routes.php if necessary
      *
      * @param  string $name
      * @return void
@@ -34,10 +34,17 @@ class ResourceGenerator {
     {
         $name = strtolower(Pluralizer::plural($name));
 
-        $this->file->append(
-            app_path() . '/routes.php',
-            "\n\nRoute::resource('" . $name . "', '" . ucwords($name) . "Controller');"
-        );
+        $routesPath = app_path() . '/routes.php';
+        $routesContent = $this->file->get($routesPath);
+
+        $resourceRoute = "Route::resource('" . $name . "', '" . ucwords($name) . "Controller');";
+
+        if ( ! strpos($routesContent, $resourceRoute))
+        {
+            return $this->file->append($routesPath, "\n\n".$resourceRoute);
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Added a check in ResourceGenerator to see if routes.php file already contains this resource's route. It's useful if you're re-running your generators.
This code doesn't check if the existing route in routes.php is commented out, because if it is, it's probably so for a reason.
