### PR TITLE
Changed $table->increments('id') to $table->integer('id', true)

### DIFF
--- a/src/Way/Generators/Generators/templates/migration/migration-up-create.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-up-create.txt
@@ -1,7 +1,7 @@
 	public function up()
 	{
 		Schema::create('{{tableName}}', function(Blueprint $table) {
-			$table->increments('id');
+			$table->integer('id', true);
 			{{methods}}
 			$table->timestamps();
 		});

--- a/src/Way/Generators/Generators/templates/migration/migration-up-pivot.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-up-pivot.txt
@@ -1,7 +1,7 @@
 	public function up()
 	{
 		Schema::create('{{tableName}}', function(Blueprint $table) {
-			$table->increments('id');
+			$table->integer('id', true);
 			{{methods}}
 		});
 	}


### PR DESCRIPTION
Changed $table->increments('id') to $table->integer('id', true) to make the columns compatible with other (foreign key) integers when using relations in InnoDB.
