### PR TITLE
Return to increments method in pivot schema

### DIFF
--- a/src/Way/Generators/Generators/templates/migration/migration-up-pivot.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-up-pivot.txt
@@ -1,7 +1,7 @@
 	public function up()
 	{
 		Schema::create('{{tableName}}', function(Blueprint $table) {
-			$table->integer('id', true);
+			$table->increments('id');
 			{{methods}}
 		});
 	}


### PR DESCRIPTION
In the commit https://github.com/JeffreyWay/Laravel-4-Generators/commit/397072563ddd3ac15ccd441d0e0a0edeb0c18f30 the increments method is fixed on creation shcema, but it's forgotten to be fixed also on the pivot template.
