### PR TITLE
Added generate:migration destroy table option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -211,6 +211,14 @@ To declare fields, use a comma-separated list of key:value:option sets, where `k
 
 Please make note of the last example, where we specify a character limit: `string[30]`. This will produce `$table->string('username', 30)->unique();`
 
+It is possible to destroy the table by issuing:
+
+	php artisan generate:migration destroy_posts_table
+	
+If you'd like to have an accurate artisan rollback option set the `fields` option as well:
+
+	php artisan generate:migration destroy_posts_table --fields="title:string, body:text"
+
 As a final demonstration, let's run a migration to remove the `completed` field from a `tasks` table.
 
     php artisan generate:migration remove_completed_from_tasks_table --fields="completed:boolean"

--- a/src/Way/Generators/Generators/MigrationGenerator.php
+++ b/src/Way/Generators/Generators/MigrationGenerator.php
@@ -119,6 +119,13 @@ class MigrationGenerator extends Generator {
                 $upMethod = $this->file->get(__DIR__ . '/templates/migration/migration-up-create.txt');
                 $fields = $this->fields ? $this->setFields('addColumn') : '';
                 break;
+
+            case 'destroy':
+            default:
+                $upMethod = $this->file->get(__DIR__ . '/templates/migration/migration-up-drop.txt');
+                $fields = $this->fields ? $this->setFields('dropColumn') : '';
+                break;
+
         }
 
         // Replace the tableName in the template
@@ -158,6 +165,14 @@ class MigrationGenerator extends Generator {
             $downMethod = $this->file->get(__DIR__ . '/templates/migration/migration-down-drop.txt');
             $fields = $this->fields ? $this->setFields('dropColumn') : '';
             break;
+
+          case 'destroy':
+          default:
+            // then we need to create the table in reverse
+            $downMethod = $this->file->get(__DIR__ . '/templates/migration/migration-down-create.txt');
+            $fields = $this->fields ? $this->setFields('addColumn') : '';
+            break;
+
         }
 
         // Replace the tableName in the template

--- a/src/Way/Generators/Generators/templates/migration/migration-down-create.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-down-create.txt
@@ -1,0 +1,8 @@
+	public function down()
+	{
+		Schema::create('{{tableName}}', function(Blueprint $table) {
+			$table->increments('id');
+			{{methods}}
+			$table->timestamps();
+		});
+	}

--- a/src/Way/Generators/Generators/templates/migration/migration-up-drop.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-up-drop.txt
@@ -1,0 +1,4 @@
+	public function up()
+	{
+		Schema::drop('{{tableName}}');
+	}


### PR DESCRIPTION
We're using Generators for a GUI driven DB administration system, and we needed to destroy tables somehow. This is what we're using. Hope it rounds the overall generate:migration functionality.
