### PR TITLE
Skipping default timestamps() and adding softDeletes()

### DIFF
--- a/src/Way/Generators/Generators/templates/migration/migration-up-create.txt
+++ b/src/Way/Generators/Generators/templates/migration/migration-up-create.txt
@@ -3,6 +3,5 @@
 		Schema::create('{{tableName}}', function(Blueprint $table) {
 			$table->increments('id');
 			{{methods}}
-			$table->timestamps();
 		});
 	}


### PR DESCRIPTION
Currently, creating table migrations uses the `fields` option as a string of the following format:
`"fieldname:type:option, fieldname:type:option"`

`$table->timestamps()` is added by default and there is no way to add `$table->softDeletes()` as option.

With this pull request I propose the use of the following syntax to further customization of these two options.
`"fieldname:type:option, fieldname:type:option, :tableoption1:tableoption2:softdeletes:notimestamps"`

Basically, when the field name is missing, this states that we are in the table options area. All the table options added will result in this output:

``` php
$table->tableoption1();
$table->tableoption2();
$table->softdeletes();
```

The only exception is the `notimestamps` option. When this is set, then we prevent the default `$table->timestamps()`.

In my opinion this syntax could be used in the future if more laravel schema table commands are added in the future.

Please pardon me if my code is not as clean as the rest of the repository. In any case, I would be glad for some feedback.

ps. Even though there are some tests in the repository, phpunit was failing before my commit with the error `Fatal error: Call to a member function make() on a non-object in /Users/dimitriossavvopoulos/Sites/Laravel-4-Generators/vendor/illuminate/support/Illuminate/Support/helpers.php on line 30`. 
