### PR TITLE
Added in doctrine dependency as this has been removed from Laravel in 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "mustache/mustache": "2.4.*"
+        "mustache/mustache": "2.4.*",
+        "doctrine/orm": "2.4.*"
     },
     "require-dev": {
         "mockery/mockery": "0.8.*",


### PR DESCRIPTION
Doctrine dependency has been removed from Laravel 4.1 but this is required by the generators package so needs to be added to the composer dependencies
