### PR TITLE
Force lowercasing of the tablename before passing it to Doctrine

### DIFF
--- a/src/Way/Generators/Generators/FormDumperGenerator.php
+++ b/src/Way/Generators/Generators/FormDumperGenerator.php
@@ -139,7 +139,7 @@ class FormDumperGenerator {
      */
     public function getTableInfo($model)
     {
-        $table = Pluralizer::plural($model);
+        $table = strtolower(Pluralizer::plural($model));
 
         return \DB::getDoctrineSchemaManager()->listTableDetails($table)->getColumns();
     }


### PR DESCRIPTION
Running generate:form is currently just returning a submit button for me. I'm not sure if this is because of a different version of the Doctrine ORM or another change elsewhere.

It comes down to the fact that you need to provide a model name, which needs to match the case of the class name, e.g. `User` and not `user`. Attempting to use `user` results in an `InvalidArgumentException` because the model can't be found.

Doctrine also expects the table name to match the case in the database, and since table names are all lowercased, this seemed like the better place to make the change. Without changing to lowercase the `->getColumns()` call just returns an empty array.
