### PR TITLE
Use delete() instead of truncate() to avoid errors.

### DIFF
--- a/src/Way/Generators/Generators/templates/seed.txt
+++ b/src/Way/Generators/Generators/templates/seed.txt
@@ -5,7 +5,7 @@ class {{className}} extends Seeder {
 	public function run()
 	{
 		// Uncomment the below to wipe the table clean before populating
-		// DB::table('{{models}}')->truncate();
+		//DB::table('{{models}}')->delete();
 
 		${{models}} = array(
 


### PR DESCRIPTION
Truncating a table with foreign keys throws a QueryException. Using the delete method empties the table just as well yet doesn't throw an exception.
