### PR TITLE
Use Input::except() instead of array_except

### DIFF
--- a/src/Way/Generators/Generators/templates/scaffold/controller.txt
+++ b/src/Way/Generators/Generators/templates/scaffold/controller.txt
@@ -98,7 +98,7 @@ class {{className}} extends BaseController {
 	 */
 	public function update($id)
 	{
-		$input = array_except(Input::all(), '_method');
+		$input = Input::except('_method');
 		$validation = Validator::make($input, {{Model}}::$rules);
 
 		if ($validation->passes())


### PR DESCRIPTION
Minor fix that uses Laravel's builtin `Input::except()` method for input filtering
