### PR TITLE
Absorb extra whitespace when parsing field names

### DIFF
--- a/src/Way/Generators/Generators/MigrationGenerator.php
+++ b/src/Way/Generators/Generators/MigrationGenerator.php
@@ -209,11 +209,11 @@ class MigrationGenerator extends Generator {
 
         if ( !$fields ) return;
 
-        $fields = preg_split('/, ?/', $fields);
+        $fields = preg_split('/, */', $fields);
 
         foreach($fields as &$bit)
         {
-            $columnInfo = preg_split('/ ?: ?/', $bit);
+            $columnInfo = preg_split('/ *: */', $bit);
 
             $bit = new \StdClass;
             $bit->name = array_shift($columnInfo);


### PR DESCRIPTION
I had an issue where I had two spaces after my comma in a --field list.  This caused lots of problems when my database column was created with a leading space.

A straightforward solution is to modify the RegEx for the preg_split functions.
Change the '?' (Match 0 or 1 instances of the preceding character) to a '*' (Match 0 or more instances of the preceding character).  This will ensure that any leading/trailing spaces will be absorbed by the split command.
