### PR TITLE
php artisan generate:form foo assume Foo model

### DIFF
--- a/src/Way/Generators/Commands/FormDumperCommand.php
+++ b/src/Way/Generators/Commands/FormDumperCommand.php
@@ -50,7 +50,8 @@ class FormDumperCommand extends BaseGeneratorCommand {
      */
     public function fire()
     {
-        if (! class_exists($model = $this->argument('model')))
+        $model = $this->argument('model');
+        if (! class_exists(ucfirst($model)))
         {
             throw new \InvalidArgumentException('Model does not exist!');
         }


### PR DESCRIPTION
Readme states:

`php artisan generate:form tweet` assumes `Tweet` model but assumes `tweet` instead, thus, the command fails. `php artisan generate:form Tweet` will also fail because it messes up getting table info.
