### PR TITLE
Fix testStoreFail to assert model never created

### DIFF
--- a/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
+++ b/src/Way/Generators/Generators/templates/scaffold/controller-test.txt
@@ -50,7 +50,7 @@ class {{className}} extends TestCase {
 
 	public function testStoreFails()
 	{
-		$this->mock->shouldReceive('create')->once();
+		$this->mock->shouldReceive('create')->never();
 		$this->validate(false);
 		$this->call('POST', '{{models}}');
 


### PR DESCRIPTION
With the current scaffold generator for the controller tests, the model
is never created on the 'fail' path.  Because of this, the PHPUnit tests
fail right out of the box.

The test now reflects never() instead of being created once().
