### PR TITLE
Added License information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "way/generators",
     "description": "",
+    "license": "MIT",
     "authors": [
         {
             "name": "Jeffrey Way",


### PR DESCRIPTION
I know the license is already included on this package but will be nice to include it at `composer.json` for a quick check on Packagist, for example.

I don't see any problem to add this, but if there are some issue, disconsider this PR.
