### PR TITLE
Accept spaces inside brackets - closes #282

### DIFF
--- a/spec/Way/Generators/Parsers/MigrationFieldsParserSpec.php
+++ b/spec/Way/Generators/Parsers/MigrationFieldsParserSpec.php
@@ -36,6 +36,9 @@ class MigrationFieldsParserSpec extends ObjectBehavior {
             ['field' => 'name', 'type' => 'double', 'args' => '15,8', 'decorators' => ['nullable', 'default(10)']],
             ['field' => 'age', 'type' => 'integer']
         ]);
+        $this->parse('name:decimal(1, 2)')->shouldReturn([
+            ['field' => 'name', 'type' => 'decimal', 'args' => '1, 2']
+        ]);
 
     }
 

--- a/src/Way/Generators/Parsers/MigrationFieldsParser.php
+++ b/src/Way/Generators/Parsers/MigrationFieldsParser.php
@@ -13,9 +13,7 @@ class MigrationFieldsParser {
     {
         if ( ! $fields) return [];
 
-        // name:string, age:integer
-        // name:string(10,2), age:integer
-        $fields = preg_split('/\s?,\s/', $fields);
+        $fields = $this->separate_into_fields($fields);
 
         $parsed = [];
 
@@ -53,6 +51,28 @@ class MigrationFieldsParser {
         }
 
         return $parsed;
+    }
+
+    private function separate_into_fields($fields) {
+        // name:string, age:integer
+        // name:string(10,2), age:integer
+        // name:string(10, 2), age:integer
+        // name:string(10), age:integer
+        $firstFields = preg_split('/\s?,\s(\D)/', $fields, null, PREG_SPLIT_DELIM_CAPTURE);
+        $singleChars = [];
+        $fields = [];
+
+        foreach($firstFields as $key => $value) {
+            if (strlen($value) == 1) {
+                $singleChars[] = $key + 1;
+            } elseif(in_array($key, $singleChars)) {
+                $fields[] = $firstFields[$key - 1] . $value;
+            } else {
+                $fields[] = $value;
+            }
+        }
+
+        return $fields;
     }
 
 }


### PR DESCRIPTION
This seemed to be easy to set up - though it's a roundabout method. Now, it also does `(\D)` - which matches all but a digit in a new key value pair. Then we loop through the matches and grab those single characters and put them in the right place.

As a note Jeffrey - the current test set up is a bit of a pain to work with. One of the `shouldReturn` failed in phpspec when I rewrote the regex but I couldn't tell which one. Could I suggest splitting them into other methods in case anyone else has similar issues?
