### PR TITLE
Add yes or no options for generate seed question

### DIFF
--- a/src/Way/Generators/Commands/ResourceGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ResourceGeneratorCommand.php
@@ -167,7 +167,7 @@ class ResourceGeneratorCommand extends Command {
     {
         $tableName = str_plural($this->getModelName($resource));
 
-        if ($this->confirm("Would you like a '$tableName' table seeder?"))
+        if ($this->confirm("Would you like a '$tableName' table seeder? [yes|no]"))
         {
             $this->call('generate:seed', compact('tableName'));
         }


### PR DESCRIPTION
The generate seed question is missing the [yes|no] options, not consistent with other questions.
