### PR TITLE
Added HTTP header verb and URL path

### DIFF
--- a/src/Way/Generators/templates/controller.txt
+++ b/src/Way/Generators/templates/controller.txt
@@ -4,6 +4,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Display a listing of the resource.
+	 * GET /$COLLECTION$
 	 *
 	 * @return Response
 	 */
@@ -14,6 +15,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Show the form for creating a new resource.
+	 * GET /$COLLECTION$/create
 	 *
 	 * @return Response
 	 */
@@ -24,6 +26,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Store a newly created resource in storage.
+	 * POST /$COLLECTION$
 	 *
 	 * @return Response
 	 */
@@ -34,6 +37,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Display the specified resource.
+	 * GET /$COLLECTION$/{id}
 	 *
 	 * @param  int  $id
 	 * @return Response
@@ -45,6 +49,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Show the form for editing the specified resource.
+	 * GET /$COLLECTION$/{id}/edit
 	 *
 	 * @param  int  $id
 	 * @return Response
@@ -56,6 +61,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Update the specified resource in storage.
+	 * PUT /$COLLECTION$/{id}
 	 *
 	 * @param  int  $id
 	 * @return Response
@@ -67,6 +73,7 @@ class $NAME$ extends \BaseController {
 
 	/**
 	 * Remove the specified resource from storage.
+	 * DELETE /$COLLECTION$/{id}
 	 *
 	 * @param  int  $id
 	 * @return Response


### PR DESCRIPTION
Just a minor adjustment. I thought it might help people new to RESTful APIs or if they often forget what method name is associated with what verb and how to access it.
