### PR TITLE
Remove short syntax array for PHP <5.4

### DIFF
--- a/src/Way/Generators/GeneratorsServiceProvider.php
+++ b/src/Way/Generators/GeneratorsServiceProvider.php
@@ -35,7 +35,7 @@ class GeneratorsServiceProvider extends ServiceProvider {
 	 */
 	public function register()
 	{
-        foreach([
+        foreach( array(
             'Model',
             'View',
             'Controller',
@@ -44,7 +44,7 @@ class GeneratorsServiceProvider extends ServiceProvider {
             'Pivot',
             'Resource',
             'Scaffold',
-            'Publisher'] as $command)
+            'Publisher') as $command)
         {
             $this->{"register$command"}();
         }


### PR DESCRIPTION
Laravel still supports PHP 5.3.7. This array gives an error on PHP versions earlier 5.4
