### PR TITLE
Typo in Command text

### DIFF
--- a/src/Way/Generators/Commands/ResourceGeneratorCommand.php
+++ b/src/Way/Generators/Commands/ResourceGeneratorCommand.php
@@ -38,7 +38,7 @@ class ResourceGeneratorCommand extends Command {
 
         // All done!
         $this->info(sprintf(
-            "All done! Don't forget to add '%s` to %s." . PHP_EOL,
+            "All done! Don't forget to add `%s` to %s." . PHP_EOL,
             "Route::resource('{$this->getTableName($resource)}', '{$this->getControllerName($resource)}');",
             "app/routes.php"
         ));


### PR DESCRIPTION
This is obviously a very small typo fix

Maybe it should only be merged later with more changes
