### PR TITLE
Use absolute paths for the templates

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -8,19 +8,19 @@ return [
     |--------------------------------------------------------------------------
     |
     */
-    'model_template_path' => 'vendor/way/generators/src/Way/Generators/templates/model.txt',
+    'model_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/model.txt',
 
-    'scaffold_model_template_path' => 'vendor/way/generators/src/Way/Generators/templates/scaffolding/model.txt',
+    'scaffold_model_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/scaffolding/model.txt',
 
-    'controller_template_path' => 'vendor/way/generators/src/Way/Generators/templates/controller.txt',
+    'controller_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/controller.txt',
 
-    'scaffold_controller_template_path' => 'vendor/way/generators/src/Way/Generators/templates/scaffolding/controller.txt',
+    'scaffold_controller_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/scaffolding/controller.txt',
 
-    'migration_template_path' => 'vendor/way/generators/src/Way/Generators/templates/migration.txt',
+    'migration_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/migration.txt',
 
-    'seed_template_path' => 'vendor/way/generators/src/Way/Generators/templates/seed.txt',
+    'seed_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/seed.txt',
 
-    'view_template_path' => 'vendor/way/generators/src/Way/Generators/templates/view.txt',
+    'view_template_path' => base_path() . 'vendor/way/generators/src/Way/Generators/templates/view.txt',
 
 
     /*


### PR DESCRIPTION
By using relative paths, it's impossible to use the generators from another directory than the root of the project. This pull request changes those paths to absolute ones, we can now run Artisan's generators from every directory.

As an example, this works now:

```
php my-laravel-project/artisan generate:model Post
```
