### PR TITLE
Fix published template path

### DIFF
--- a/src/Way/Generators/Commands/PublishTemplatesCommand.php
+++ b/src/Way/Generators/Commands/PublishTemplatesCommand.php
@@ -74,7 +74,7 @@ class PublishTemplatesCommand extends Command {
     protected function getOptions()
     {
         return [
-            ['path', null, InputOption::VALUE_OPTIONAL, 'Which directory should the templates be copied to?', app_path('templates')]
+            ['path', null, InputOption::VALUE_OPTIONAL, 'Which directory should the templates be copied to?', 'app/templates']
         ];
     }
 


### PR DESCRIPTION
With `base_path()` now being used in config.php, the template paths break when publishing the templates with the default path.

Example:   /Users/nathan/Development/laravel/playground//Users/nathan/Development/laravel/playground/app/templates/model.txt

This change fixes that path.
