### PR TITLE
Allow schema.txt published template to be used

### DIFF
--- a/src/Way/Generators/Syntax/Table.php
+++ b/src/Way/Generators/Syntax/Table.php
@@ -2,6 +2,7 @@
 
 use Way\Generators\Compilers\TemplateCompiler;
 use Way\Generators\Filesystem\Filesystem;
+use Config;
 
 abstract class Table {
 
@@ -32,7 +33,8 @@ abstract class Table {
      */
     protected function getTemplate()
     {
-        return $this->file->get(__DIR__.'/../templates/schema.txt');
+        $templatePath = Config::get("generators::config.schema_template_path");
+        return $this->file->get($templatePath);
     }
 
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -18,6 +18,8 @@ return [
 
     'migration_template_path' => base_path('vendor/way/generators/src/Way/Generators/templates/migration.txt'),
 
+    'schema_template_path' => base_path('vendor/way/generators/src/Way/Generators/templates/schema.txt'),
+
     'seed_template_path' => base_path('vendor/way/generators/src/Way/Generators/templates/seed.txt'),
 
     'view_template_path' => base_path('vendor/way/generators/src/Way/Generators/templates/view.txt'),


### PR DESCRIPTION
Currently, the default schema.txt is always used even after publishing the templates. This uses `schema_template_path`to allow that template to be overridden.
