### PR TITLE
Feature: Set a field as an ENUM.

### DIFF
--- a/src/Way/Generators/Parsers/MigrationFieldsParser.php
+++ b/src/Way/Generators/Parsers/MigrationFieldsParser.php
@@ -41,10 +41,15 @@ class MigrationFieldsParser {
                 $type = $matches[1];
                 $args = $matches[2];
             }
+            if (strpos($type, "enum") !== true && count($chunks) > 0 && preg_match("/array(.*)/", $chunks[0], $matches))
+            {
+                $args = $matches[0];
+            }
 
             // Finally, anything that remains will
             // be our decorators
-            $decorators = $chunks;
+            if (isset($args)) $decorators = array_diff($chunks, array($args));
+            else $decorators = $chunks;
 
             $parsed[$index] = ['field' => $property, 'type' => $type];
 


### PR DESCRIPTION
Allow add enum type field

Example:

php artisan generate:scaffold user --fields="login:string:unique, access_level:enum:array('level-1','level-2','level-3','level-4'), :softDeletes"

Important: the array of values must be the third argument
