### PR TITLE
Optional space after the field

### DIFF
--- a/src/Way/Generators/Parsers/MigrationFieldsParser.php
+++ b/src/Way/Generators/Parsers/MigrationFieldsParser.php
@@ -15,7 +15,7 @@ class MigrationFieldsParser {
 
         // name:string, age:integer
         // name:string(10,2), age:integer
-        $fields = preg_split('/\s?,\s/', $fields);
+        $fields = preg_split('/\s?,\s?/', $fields);
 
         $parsed = [];
 


### PR DESCRIPTION
I saw no reason for it to have the space after the comma, I suggest putting porting as an option if you do not have a reason. 
If forgotten space he makes a migration errors
