### PR TITLE
Fix update method in controller scaffold

### DIFF
--- a/src/Way/Generators/templates/scaffolding/controller.txt
+++ b/src/Way/Generators/templates/scaffolding/controller.txt
@@ -74,8 +74,8 @@ class $NAME$ extends Controller {
 	public function update($id)
 	{
 		$$RESOURCE$ = $MODEL$::findOrFail($id);
-
-		$$RESOURCE$->update(Request::get());
+		$$RESOURCE$->fill(Request::get());
+		$$RESOURCE$->save();
 
 		return Redirect::route('$COLLECTION$.index');
 	}


### PR DESCRIPTION
Using update() on model prevents updating() / updated() events from being triggered.
